### PR TITLE
Selection Mode and pending filesystem actions

### DIFF
--- a/lua/trek.lua
+++ b/lua/trek.lua
@@ -15,9 +15,10 @@ end
 
 ---@param path string
 M.open = function(path)
-  local dir = fs.get_directory_of_path(path)
+  assert(path ~= nil and type(path) == "string", "path is not a string")
+  local dir_path = fs.get_directory_of_path(path)
   window.opened_from_path = path
-  explorer.open(dir)
+  explorer.open(dir_path)
 end
 
 return M

--- a/lua/trek/buffer.lua
+++ b/lua/trek/buffer.lua
@@ -24,7 +24,6 @@ function M.on_lines_changed(buf_id, cb)
         deleted_codepoints,
         deleted_codeunits
     )
-      -- table.insert(M.events, { ... })
       if not discarded_first then
         discarded_first = true
       else

--- a/lua/trek/buffer.lua
+++ b/lua/trek/buffer.lua
@@ -10,7 +10,7 @@ local discarded_first = false
 ---@param buf_id integer
 ---@param cb function()
 function M.on_lines_changed(buf_id, cb)
-  --TODO it's annoying that this also triggers when i call buf_set_lines
+  --TODO: it's annoying that this also triggers when i call buf_set_lines
   discarded_first = false
   vim.api.nvim_buf_attach(buf_id, false, {
     on_lines = function(

--- a/lua/trek/buffer.lua
+++ b/lua/trek/buffer.lua
@@ -10,6 +10,7 @@ local discarded_first = false
 ---@param buf_id integer
 ---@param cb function()
 function M.on_lines_changed(buf_id, cb)
+  --TODO it's annoying that this also triggers when i call buf_set_lines
   discarded_first = false
   vim.api.nvim_buf_attach(buf_id, false, {
     on_lines = function(
@@ -47,7 +48,7 @@ function M.buffer_update_file(buf_id, path)
   vim.loop.fs_close(fd)
   if not is_text then
     local user_config = require("trek.config").get_config()
-    utils.set_buflines(buf_id, { "-Non-text-file-"})
+    utils.set_buflines(buf_id, { "-Non-text-file-" })
     return
   end
 

--- a/lua/trek/config.lua
+++ b/lua/trek/config.lua
@@ -9,6 +9,7 @@ local M = {}
 ---@field go_in string
 ---@field go_out string
 ---@field synchronize string
+---@field mark_entry string
 ---
 ---@class trek.Config
 ---@field keymaps trek.KeymapsConfig
@@ -23,6 +24,7 @@ M.config = {
     go_in = "<Right>",
     go_out = "<Left>",
     synchronize = "=",
+    mark_entry = "<Tab>",
   },
   --TODO use_as_default_explorer = true,
   windows = {
@@ -50,6 +52,7 @@ function M.setup_config(config)
     ["keymaps.go_in"] = { config.keymaps.go_in, "string" },
     ["keymaps.go_out"] = { config.keymaps.go_out, "string" },
     ["keymaps.synchronize"] = { config.keymaps.synchronize, "string" },
+    ["keymaps.mark_entry"] = { config.keymaps.mark_entry, "string" },
 
     -- ["options.use_as_default_explorer"] = { config.options.use_as_default_explorer, "boolean" },
     -- ["options.permanent_delete"] = { config.options.permanent_delete, "boolean" },

--- a/lua/trek/config.lua
+++ b/lua/trek/config.lua
@@ -26,7 +26,8 @@ M.config = {
     synchronize = "=",
     toggle_entry_marked = "<Tab>",
   },
-  --TODO use_as_default_explorer = true,
+
+  --TODO: use_as_default_explorer = true,
   windows = {
     preview_width_percent = 50,
   },

--- a/lua/trek/config.lua
+++ b/lua/trek/config.lua
@@ -29,14 +29,14 @@ M.config = {
   },
 
   -- Whether to delete permanently or move into module-specific trash
-  -- permanent_delete = true,
   -- -- Whether to use for editing directories
   -- use_as_default_explorer = true,
   -- -- Whether to be prompted for confirmation when performing filesystem actions
   windows = {
-    preview_width_percent = 50
+    preview_width_percent = 50,
   },
   confirm_fs_actions = true,
+  permanent_delete = true,
 }
 
 M.default_config = vim.deepcopy(M.config)

--- a/lua/trek/config.lua
+++ b/lua/trek/config.lua
@@ -14,28 +14,21 @@ local M = {}
 ---@field keymaps trek.KeymapsConfig
 ---@field lsp trek.LSPConfig
 M.config = {
-  -- Customization of shown content
   lsp = {
     timeout_ms = 500,
     autosave_changes = true,
   },
-  -- Module mappings created only inside explorer.
-  -- Use `''` (empty string) to not create one.
   keymaps = {
     close = "q",
     go_in = "<Right>",
     go_out = "<Left>",
     synchronize = "=",
   },
-
-  -- Whether to delete permanently or move into module-specific trash
-  -- -- Whether to use for editing directories
-  -- use_as_default_explorer = true,
-  -- -- Whether to be prompted for confirmation when performing filesystem actions
+  --TODO use_as_default_explorer = true,
   windows = {
     preview_width_percent = 50,
   },
-  confirm_fs_actions = true,
+  confirm_fs_actions = false,
   permanent_delete = true,
 }
 

--- a/lua/trek/config.lua
+++ b/lua/trek/config.lua
@@ -9,7 +9,7 @@ local M = {}
 ---@field go_in string
 ---@field go_out string
 ---@field synchronize string
----@field mark_entry string
+---@field toggle_entry_marked string
 ---
 ---@class trek.Config
 ---@field keymaps trek.KeymapsConfig
@@ -24,7 +24,7 @@ M.config = {
     go_in = "<Right>",
     go_out = "<Left>",
     synchronize = "=",
-    mark_entry = "<Tab>",
+    toggle_entry_marked = "<Tab>",
   },
   --TODO use_as_default_explorer = true,
   windows = {
@@ -52,7 +52,7 @@ function M.setup_config(config)
     ["keymaps.go_in"] = { config.keymaps.go_in, "string" },
     ["keymaps.go_out"] = { config.keymaps.go_out, "string" },
     ["keymaps.synchronize"] = { config.keymaps.synchronize, "string" },
-    ["keymaps.mark_entry"] = { config.keymaps.mark_entry, "string" },
+    ["keymaps.toggle_entry_marked"] = { config.keymaps.toggle_entry_marked, "string" },
 
     -- ["options.use_as_default_explorer"] = { config.options.use_as_default_explorer, "boolean" },
     -- ["options.permanent_delete"] = { config.options.permanent_delete, "boolean" },

--- a/lua/trek/explorer.lua
+++ b/lua/trek/explorer.lua
@@ -37,7 +37,7 @@ local M = {
   opened = false,
   stop_listening_on_next_buf_change = false,
   cursor_history = {},
-  pending_fs_actions = {}
+  pending_fs_actions = {},
 }
 
 function M.teardown()
@@ -95,15 +95,22 @@ end
 
 function M.synchronize()
   local fs_actions = fs.compute_fs_actions(M.dir.path, M.window.center.buf_id)
-  if fs_actions == nil then return end
+  if fs_actions == nil then
+    return
+  end
   for path, pending_fs_actions in pairs(M.pending_fs_actions) do
     assert(
       pending_fs_actions ~= nil
-      and pending_fs_actions.delete ~= nil and fs_actions.delete ~= nil
-      and pending_fs_actions.copy ~= nil and fs_actions.copy ~= nil
-      and pending_fs_actions.create ~= nil and fs_actions.create ~= nil
-      and pending_fs_actions.move ~= nil and fs_actions.move ~= nil
-      and pending_fs_actions.rename ~= nil and fs_actions.rename ~= nil,
+        and pending_fs_actions.delete ~= nil
+        and fs_actions.delete ~= nil
+        and pending_fs_actions.copy ~= nil
+        and fs_actions.copy ~= nil
+        and pending_fs_actions.create ~= nil
+        and fs_actions.create ~= nil
+        and pending_fs_actions.move ~= nil
+        and fs_actions.move ~= nil
+        and pending_fs_actions.rename ~= nil
+        and fs_actions.rename ~= nil,
       "fsactions: shouldnt be possible for any of this to be nil"
     )
     if path ~= M.path then
@@ -266,6 +273,8 @@ function M.enter_selection_mode()
     M.exit_selection_mode()
   end, opts)
   vim.keymap.set("n", "d", M.delete_marked_entries, opts)
+  vim.keymap.set("n", "q", M.exit_selection_mode, opts)
+  vim.keymap.set("n", "<Esc>", M.exit_selection_mode, opts)
 end
 
 function M.yank_marked_entries()
@@ -300,13 +309,17 @@ function M.delete_marked_entries()
 end
 
 function M.exit_selection_mode()
-  if M.mode == "normal" then return end
+  if M.mode == "normal" then
+    return
+  end
   window.hide_selection_mode_info()
   for _, entry in ipairs(M.dir.entries) do
     entry.marked = false
   end
   M.mode = "normal"
   local opts = { silent = true, buffer = M.window.center.buf_id }
+  vim.keymap.del("n", "q", opts)
+  vim.keymap.del("n", "<Esc>", opts)
   vim.keymap.del("n", "y", opts)
   vim.keymap.del("n", "d", opts)
   window.render_dir(M.dir, M.window.center.buf_id)

--- a/lua/trek/explorer.lua
+++ b/lua/trek/explorer.lua
@@ -318,22 +318,39 @@ function M.exit_selection_mode()
   end
   M.mode = "normal"
   local opts = { silent = true, buffer = M.window.center.buf_id }
-  vim.keymap.del("n", "q", opts)
-  vim.keymap.del("n", "<Esc>", opts)
-  vim.keymap.del("n", "y", opts)
-  vim.keymap.del("n", "d", opts)
+  local keymaps = config.get_config().keymaps
+  local selection_mode_keymaps = { "q", "<Esc>", "y", "d" }
+  local user_keymaps = M.get_user_keymaps()
+  for _, keymap in ipairs(selection_mode_keymaps) do
+    vim.keymap.del("n", keymap, opts)
+    for lhs, rhs in pairs(user_keymaps) do
+      if lhs == keymap then
+        vim.keymap.set("n", lhs, rhs, opts)
+      end
+    end
+  end
   window.render_dir(M.dir, M.window.center.buf_id)
+end
+
+---@return table<string, string|function>
+function M.get_user_keymaps()
+  local config_keymaps = config.get_config().keymaps
+  return {
+    [config_keymaps.go_out] = M.go_out,
+    [config_keymaps.go_in] = M.go_in,
+    [config_keymaps.close] = M.close,
+    [config_keymaps.synchronize] = M.synchronize,
+    [config_keymaps.toggle_entry_marked] = M.toggle_entry_marked,
+    p = "o<Esc>p",
+  }
 end
 
 function M.setup_keymaps()
   local opts = { silent = true, buffer = M.window.center.buf_id }
-  local keymaps = config.get_config().keymaps
-  vim.keymap.set("n", "p", "o<Esc>p", opts)
-  vim.keymap.set("n", keymaps.go_out, M.go_out, opts)
-  vim.keymap.set("n", keymaps.go_in, M.go_in, opts)
-  vim.keymap.set("n", keymaps.close, M.close, opts)
-  vim.keymap.set("n", keymaps.synchronize, M.synchronize, opts)
-  vim.keymap.set("n", keymaps.toggle_entry_marked, M.toggle_entry_marked, opts)
+  local keymaps = M.get_user_keymaps()
+  for lhs, rhs in pairs(keymaps) do
+    vim.keymap.set("n", lhs, rhs, opts)
+  end
 end
 
 return M

--- a/lua/trek/fs.lua
+++ b/lua/trek/fs.lua
@@ -202,7 +202,7 @@ function M.apply_fs_actions(fs_actions)
   -- Delete last to not lose anything too early (just in case)
   for _, path in ipairs(fs_actions.delete) do
     local config = require("trek.config").get_config()
-    local ok, success = pcall(M.delete, path, config.options.permanent_delete)
+    local ok, success = pcall(M.delete, path, config.permanent_delete)
     local data = { action = "delete", from = path }
     if ok and success then
       utils.trigger_event("TrekActionDelete", data)

--- a/lua/trek/fs.lua
+++ b/lua/trek/fs.lua
@@ -91,7 +91,6 @@ end
 ---@param path string
 ---@param buf_id integer
 function M.compute_fs_actions(path, buf_id)
-  -- Compute differences
   local dir = M.get_dir_content(path)
   local children_ids = utils.map(dir.entries, function(entry)
     return entry.id
@@ -431,7 +430,7 @@ end
 function M.get_directory_of_path(path)
   local full_path = M.full_path(path)
   local stat = vim.loop.fs_stat(full_path)
-
+  assert(stat ~= nil, "not a valid path")
   if stat and stat.type == "directory" then
     return full_path
   else

--- a/lua/trek/fs.lua
+++ b/lua/trek/fs.lua
@@ -35,18 +35,6 @@ local lsp_helpers = require("trek.lsp.helpers")
 ---@field url string
 ---@field column string
 ---@field value any
----
----@class trek.Directory
----@field path string
----@field entries trek.DirectoryEntry[]
-
----@class trek.DirectoryEntry
----@field id integer
----@field fs_type "file" | "directory"
----@field name string
----@field path string
----@field icon string | nil
----@field icon_hl_group string | nil
 
 ---@class trek.Filesystem
 ---@field directory trek.Directory
@@ -437,6 +425,7 @@ function M.get_directory_of_path(path)
     return M.get_parent(full_path) or ""
   end
 end
+
 ---@param path string
 ---@return string | nil
 function M.get_parent(path)
@@ -467,6 +456,7 @@ function M.get_type(path)
   end
   return vim.fn.isdirectory(path) == 1 and "directory" or "file"
 end
+
 function M.warn_existing_path(path, action)
   utils.notify(string.format("Can not %s %s. Target path already exists.", action, path), "WARN")
   return false

--- a/lua/trek/fs.lua
+++ b/lua/trek/fs.lua
@@ -76,8 +76,16 @@ function M.get_dir_content(path)
   }
 end
 
+---@class trek.FsActions
+---@field create string[]
+---@field delete string[]
+---@field copy table[]
+---@field rename table[]
+---@field move table[]
+
 ---@param path string
 ---@param buf_id integer
+---@return trek.FsActions|nil
 function M.compute_fs_actions(path, buf_id)
   local dir = M.get_dir_content(path)
   local children_ids = utils.map(dir.entries, function(entry)

--- a/lua/trek/fs.lua
+++ b/lua/trek/fs.lua
@@ -283,7 +283,7 @@ function M.move(from, to)
   -- restores previous concealed path index)
   M.replace_path_in_index(from, to)
 
-  -- TODO Rename in loaded buffers
+  -- TODO: Rename in loaded buffers
   -- for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
   --   M.event_listeners.rename_loaded_buffer(buf_id, from, to)
   -- end

--- a/lua/trek/highlights.lua
+++ b/lua/trek/highlights.lua
@@ -54,8 +54,7 @@ function M.add_highlights(buf_id, entries)
     local icon_start, name_start = line:match("^/%d+/().-()/")
     icon_start = icon_start - 1
     if is_selection_mode then
-      set_hl(i - 1, icon_start,
-        { hl_group = "WarningMsg", end_col = icon_start + 1, right_gravity = false })
+      set_hl(i - 1, icon_start, { hl_group = "WarningMsg", end_col = icon_start + 1, right_gravity = false })
       icon_start = icon_start + 1
     end
     if entry.icon_hl_group ~= nil then

--- a/lua/trek/highlights.lua
+++ b/lua/trek/highlights.lua
@@ -53,14 +53,13 @@ function M.add_highlights(buf_id, entries)
     local line = lines[i]
     local icon_start, name_start = line:match("^/%d+/().-()/")
     icon_start = icon_start - 1
+    if is_selection_mode then
+      set_hl(i - 1, icon_start,
+        { hl_group = "WarningMsg", end_col = icon_start + 1, right_gravity = false })
+      icon_start = icon_start + 1
+    end
     if entry.icon_hl_group ~= nil then
       local icon_opts = { hl_group = entry.icon_hl_group, end_col = name_start - 1, right_gravity = false }
-      local before_icon = "󰄲  "
-      if is_selection_mode then
-        set_hl(i - 1, icon_start,
-          { hl_group = "Normal", end_col = icon_start + #before_icon - 1, right_gravity = false })
-        icon_start = icon_start + #before_icon
-      end
       set_hl(i - 1, icon_start, icon_opts)
     end
     local name_opts = { hl_group = hl_group, end_row = i, end_col = 0, right_gravity = false }

--- a/lua/trek/lsp/workspace.lua
+++ b/lua/trek/lsp/workspace.lua
@@ -313,8 +313,6 @@ function M.did_rename_files(files)
           }
         end, matching_files),
       }
-      print("about to notify lsp about didRenameFiles")
-      vim.print(params)
       ---@diagnostic disable-next-line: invisible
       client.notify(ms.workspace_didRenameFiles, params)
     end

--- a/lua/trek/utils.lua
+++ b/lua/trek/utils.lua
@@ -16,6 +16,20 @@ end
 
 ---@generic T
 ---@param list T[]
+---@param predicate function(value: T): boolean
+---@return T[]
+function M.filter(list, predicate)
+  local result = {}
+  for _, value in ipairs(list) do
+    if predicate(value) then
+      table.insert(result, value)
+    end
+  end
+  return result
+end
+
+---@generic T
+---@param list T[]
 ---@param cb function(value: `T`): boolean
 ---@return T | nil
 function M.find(list, cb)

--- a/lua/trek/utils.lua
+++ b/lua/trek/utils.lua
@@ -80,7 +80,7 @@ end
 ---@param scheme nil|string
 ---@return nil|trek.Adapter
 function M.get_adapter_by_scheme(scheme)
-  ---TODO: implement, but we dont need it to be as complex as in oil
+  ---TODO:: implement, but we dont need it to be as complex as in oil
   ---seems like in the lsp stuff it's only used for the name property
   return { name = "files" }
 end

--- a/lua/trek/window.lua
+++ b/lua/trek/window.lua
@@ -3,8 +3,8 @@ local highlights = require("trek.highlights")
 local buffer = require("trek.buffer")
 local utils = require("trek.utils")
 
-local icon_checked = "󰄲"
-local icon_not_checked = "󰄮"
+local icon_checked = ""
+local icon_not_checked = ""
 
 local function get_default_window()
   return {

--- a/lua/trek/window.lua
+++ b/lua/trek/window.lua
@@ -39,6 +39,7 @@ local M = {
 function M.open()
   ---@class trek.WindowData
   local window = get_default_window()
+  print('open window')
   vim.cmd("tabnew")
   window.left.win_id = vim.api.nvim_get_current_win()
   vim.cmd("vsplit")

--- a/lua/trek/window.lua
+++ b/lua/trek/window.lua
@@ -6,6 +6,15 @@ local utils = require("trek.utils")
 local icon_checked = "󰄲"
 local icon_not_checked = "󰄮"
 
+local function get_default_window()
+  return {
+    left = { win_id = nil, buf_id = nil },
+    center = { win_id = nil, buf_id = nil },
+    right = { win_id = nil, buf_id = nil },
+    selection_mode_info = { win_id = nil, buf_id = nil },
+  }
+end
+
 ---@class trek.Window
 ---@field window trek.WindowData
 ---@field opened_from_path string
@@ -13,36 +22,38 @@ local icon_not_checked = "󰄮"
 local M = {
   cursor_history = {},
   opened = false,
+  window = get_default_window()
 }
 
+---@class trek.WindowPane
+---@field win_id integer | nil
+---@field buf_id integer | nil
+---
 ---@class trek.WindowData
----@field left_win_id integer
----@field center_win_id integer
----@field right_win_id integer
----@field left_buf_id integer
----@field center_buf_id integer
----@field right_buf_id integer
----@field tab_id integer
+---@field left trek.WindowPane
+---@field center trek.WindowPane
+---@field right trek.WindowPane
+---@field selection_mode_info trek.WindowPane
 
 ---@return trek.WindowData
 function M.open()
   ---@class trek.WindowData
-  local window = {}
+  local window = get_default_window()
   vim.cmd("tabnew")
-  window.left_win_id = vim.api.nvim_get_current_win()
+  window.left.win_id = vim.api.nvim_get_current_win()
   vim.cmd("vsplit")
-  window.center_win_id = vim.api.nvim_get_current_win()
+  window.center.win_id = vim.api.nvim_get_current_win()
   vim.cmd("vsplit")
-  window.right_win_id = vim.api.nvim_get_current_win()
-  window.left_buf_id = vim.api.nvim_create_buf(false, true)
-  window.center_buf_id = vim.api.nvim_create_buf(false, true)
-  window.right_buf_id = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_win_set_buf(window.left_win_id, window.left_buf_id)
-  vim.api.nvim_win_set_buf(window.center_win_id, window.center_buf_id)
-  vim.api.nvim_win_set_buf(window.right_win_id, window.right_buf_id)
-  vim.api.nvim_buf_set_name(window.center_buf_id, "Trek File Explorer")
-  highlights.set_cursorline(window.left_win_id, highlights.ns_id.left_window)
-  highlights.set_cursorline(window.center_win_id, highlights.ns_id.center_window)
+  window.right.win_id = vim.api.nvim_get_current_win()
+  window.left.buf_id = vim.api.nvim_create_buf(false, true)
+  window.center.buf_id = vim.api.nvim_create_buf(false, true)
+  window.right.buf_id = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(window.left.win_id, window.left.buf_id)
+  vim.api.nvim_win_set_buf(window.center.win_id, window.center.buf_id)
+  vim.api.nvim_win_set_buf(window.right.win_id, window.right.buf_id)
+  vim.api.nvim_buf_set_name(window.center.buf_id, "Trek File Explorer")
+  highlights.set_cursorline(window.left.win_id, highlights.ns_id.left_window)
+  highlights.set_cursorline(window.center.win_id, highlights.ns_id.center_window)
   window.tab_id = vim.api.nvim_get_current_tabpage()
   M.window = window
   M.opened = true
@@ -50,9 +61,9 @@ function M.open()
 end
 
 function M.close()
-  vim.api.nvim_buf_delete(M.window.left_buf_id, { force = true })
-  vim.api.nvim_buf_delete(M.window.center_buf_id, { force = true })
-  vim.api.nvim_buf_delete(M.window.right_buf_id, { force = true })
+  vim.api.nvim_buf_delete(M.window.left.buf_id, { force = true })
+  vim.api.nvim_buf_delete(M.window.center.buf_id, { force = true })
+  vim.api.nvim_buf_delete(M.window.right.buf_id, { force = true })
   M.opened = false
 end
 
@@ -72,7 +83,7 @@ end
 ---@param win_id integer
 ---@param row integer
 function M.set_cursor(win_id, row)
-  local cursor = vim.api.nvim_win_get_cursor(M.window.center_win_id)
+  local cursor = vim.api.nvim_win_get_cursor(M.window.center.win_id)
   cursor[1] = row
   if type(cursor) ~= "table" then
     return
@@ -129,14 +140,14 @@ function M.render_preview(entry)
     return
   end
   if entry.id == -1 then
-    return utils.set_buflines(M.window.right_buf_id, { "-file-not-created-" })
+    return utils.set_buflines(M.window.right.buf_id, { "-file-not-created-" })
   end
   if entry.fs_type == "directory" then
     local dir = fs.get_dir_content(entry.path)
-    M.render_dir(dir, M.window.right_buf_id)
+    M.render_dir(dir, M.window.right.buf_id)
   end
   if entry.fs_type == "file" then
-    buffer.buffer_update_file(M.window.right_buf_id, entry.path)
+    buffer.buffer_update_file(M.window.right.buf_id, entry.path)
   end
 end
 
@@ -149,10 +160,10 @@ function M.render_current_dir(path)
       return entry.path == M.opened_from_path
     end)
   end
-  M.render_dir(dir, M.window.center_buf_id)
+  M.render_dir(dir, M.window.center.buf_id)
   if entry_row ~= -1 then
     vim.schedule(function()
-      M.set_cursor(M.window.center_win_id, entry_row)
+      M.set_cursor(M.window.center.win_id, entry_row)
     end)
   end
 end
@@ -164,9 +175,9 @@ function M.render_parent_dir(parent_path, path)
   local parent_entry_row = utils.find_index(dir.entries, function(entry)
     return entry.path == path
   end)
-  M.render_dir(dir, M.window.left_buf_id)
+  M.render_dir(dir, M.window.left.buf_id)
   vim.schedule(function()
-    M.set_cursor(M.window.left_win_id, parent_entry_row)
+    M.set_cursor(M.window.left.win_id, parent_entry_row)
   end)
 end
 
@@ -200,15 +211,15 @@ function M.render_dirs(path)
   if parent_path ~= nil then
     M.render_parent_dir(parent_path, path)
   end
-  vim.api.nvim_set_current_win(M.window.center_win_id)
+  vim.api.nvim_set_current_win(M.window.center.win_id)
 end
 
 ---@param entries trek.DirectoryEntry[]
 ---@return trek.DirectoryEntry
 function M.update_selected_entry(entries)
   --NOTE not sure if I like this, could be annoying in visual mode etc.
-  M.reset_cursor(M.window.center_win_id, M.window.center_buf_id)
-  local row = vim.api.nvim_win_get_cursor(M.window.center_win_id)[1]
+  M.reset_cursor(M.window.center.win_id, M.window.center.buf_id)
+  local row = vim.api.nvim_win_get_cursor(M.window.center.win_id)[1]
   return entries[row]
 end
 
@@ -298,16 +309,22 @@ M.mark_clean = vim.schedule_wrap(function(left_win_id, center_win_id)
   )
 end)
 
-function M.show_selection_mode_info()
-  local buf_id = vim.api.nvim_create_buf(false, true)
-  local text = "3 item(s) selected"
-  utils.set_buflines(buf_id, { text })
-  local win_width = vim.api.nvim_win_get_width(0)
-  local win_height = vim.api.nvim_win_get_height(0)
+function M.hide_selection_mode_info()
+  if M.window.selection_mode_info.win_id == nil then return end
+  vim.api.nvim_win_close(M.window.selection_mode_info.win_id, true)
+  M.window.selection_mode_info.win_id = nil
+  M.window.selection_mode_info.buf_id = nil
+end
+
+---@param text string
+function M.create_selection_mode_info_win(text)
+  M.window.selection_mode_info.buf_id = vim.api.nvim_create_buf(false, true)
+  local win_width = vim.api.nvim_win_get_width(M.window.center.win_id)
+  local win_height = vim.api.nvim_win_get_height(M.window.center.win_id)
 
   local ns = vim.api.nvim_create_namespace("TrekSelectionModeInfo")
   vim.api.nvim_set_hl(ns, "CursorLine", { bg = highlights.colors.normal, fg = highlights.colors.text })
-  local win_id = vim.api.nvim_open_win(buf_id, false, {
+  M.window.selection_mode_info.win_id = vim.api.nvim_open_win(M.window.selection_mode_info.buf_id, false, {
     relative = 'win',
     width = #text + 4,
     height = 1,
@@ -315,9 +332,23 @@ function M.show_selection_mode_info()
     col = win_width,
     anchor = "SE",
     border = "rounded",
-    win = M.window.center_win_id,
+    win = M.window.center.win_id,
   })
-  vim.api.nvim_win_set_hl_ns(win_id, ns)
+  vim.api.nvim_win_set_hl_ns(M.window.selection_mode_info.win_id, ns)
+end
+
+---@param number_marked_entries integer
+function M.show_selection_mode_info(number_marked_entries)
+  local text = M.get_selection_mode_info_text(number_marked_entries)
+  if M.window.selection_mode_info.win_id == nil then
+    M.create_selection_mode_info_win(text)
+  end
+  utils.set_buflines(M.window.selection_mode_info.buf_id, { text })
+end
+
+---@param number_marked_entries integer
+function M.get_selection_mode_info_text(number_marked_entries)
+  return tostring(number_marked_entries) .. " items selected"
 end
 
 return M

--- a/lua/trek/window.lua
+++ b/lua/trek/window.lua
@@ -5,6 +5,7 @@ local utils = require("trek.utils")
 ---@class trek.Window
 ---@field window trek.WindowData
 ---@field opened_from_path string
+---TODO this seems sketchy
 local M = {
   cursor_history = {},
   opened = false,
@@ -253,8 +254,6 @@ function M.restore_window_opts(win_id)
     vim.api.nvim_win_call(win_id, function()
       vim.fn.clearmatches()
     end)
-  else
-    print("No original options stored for window " .. win_id)
   end
 end
 

--- a/lua/trek/window.lua
+++ b/lua/trek/window.lua
@@ -18,7 +18,7 @@ end
 ---@class trek.Window
 ---@field window trek.WindowData
 ---@field opened_from_path string
----TODO this seems sketchy
+---TODO: this seems sketchy
 local M = {
   cursor_history = {},
   opened = false,


### PR DESCRIPTION
- entries in the center window can be marked with `<Tab>`
- selection mode is active as long as at least one entry is marked
- selection mode info window displaying number of marked entries
- additional icon as indicator for marked/unmarked entries
- use y/d to yank/delete marked entries; these keymaps only work in selection mode
- use `<Esc>` or `q` to exit selection mode without performing any action
- when changing directory (in or out) pending fs actions are stored and will be performed at the next synchronize action; previously there was faulty behavior when for example trying to move a file to a child directory by deleting, going to the child dir and then pasting